### PR TITLE
Tweeter: Add workaround for new Zeppelin version

### DIFF
--- a/tweeter/1.9/README.md
+++ b/tweeter/1.9/README.md
@@ -39,12 +39,12 @@ __Tip:__ You can also install DC/OS packages from the DC/OS CLI with the [`dcos 
 Now we want to install **Zeppelin** with a specific version from the CLI to work around a temporary package issue in the latest version, use the [zeppelin-config.json](zeppelin-config.json) in this repository in the following command:
 
     ```bash
-    $dcos package install zeppelin --package-version=0.5.6 --options=zeppelin-config.json
+    $ dcos package install zeppelin --package-version=0.5.6 --options=zeppelin-config.json
     ```
 
-    **Tip:** It can take up to 10 minutes for Cassandra to initialize with DC/OS because of race conditions.
+**Tip:** It can take up to 10 minutes for Cassandra to initialize with DC/OS because of race conditions.
 
-    ![Deployed services](./img/tweeter-deployed-services.png)
+![Deployed services](./img/tweeter-deployed-services.png)
 
 # Deploy the containerized app
 

--- a/tweeter/1.9/README.md
+++ b/tweeter/1.9/README.md
@@ -36,15 +36,15 @@ __Tip:__ You can also install DC/OS packages from the DC/OS CLI with the [`dcos 
 1.  Find the **marathon-lb** package and click the **Install Package** button and accept the default installation.
 1.  Monitor the **Services** tab to watch as your microservices are deployed on DC/OS. You will see the Health status go from Idle to Unhealthy, and finally to Healthy as the nodes come online. This may take several minutes.
 
-Now we want to install **Zeppelin** with a specific version from the CLI to work around a temporary package issue in the latest version, use the [zeppelin-config.json](zeppelin-config.json) in this repository in the following command:
+Now we want to install **Zeppelin** with a specific version from the CLI to work around a temporary package issue in the latest version, use the [zeppelin-config.json](zeppelin-config.json) in this repository.
 
     ```bash
     $ dcos package install zeppelin --package-version=0.5.6 --options=zeppelin-config.json
     ```
 
-**Tip:** It can take up to 10 minutes for Cassandra to initialize with DC/OS because of race conditions.
+    **Tip:** It can take up to 10 minutes for Cassandra to initialize with DC/OS because of race conditions.
 
-![Deployed services](./img/tweeter-deployed-services.png)
+    ![Deployed services](./img/tweeter-deployed-services.png)
 
 # Deploy the containerized app
 

--- a/tweeter/1.9/README.md
+++ b/tweeter/1.9/README.md
@@ -27,18 +27,20 @@ This tutorial demonstrates how you can build a complete IoT pipeline on DC/OS in
 *  The public IP address of your public agent node. After you have installed DC/OS with a public agent node declared, you can [navigate to the public IP address][9] of your public agent node.
 
 # Install services
-From the DC/OS web interface [**Universe**](https://dcos.io/docs/1.9/usage/webinterface/#universe) tab, install Cassandra, Kafka, Marathon-LB, and Zeppelin.
+From the DC/OS web interface [**Universe**](https://dcos.io/docs/1.9/usage/webinterface/#universe) tab, install Cassandra, Kafka, and Marathon-LB.
 
 __Tip:__ You can also install DC/OS packages from the DC/OS CLI with the [`dcos package install`][11] command.
 
 1.  Find the **cassandra** package and click the **Install Package** button and accept the default installation. Cassandra will spin up to at least 3 nodes.
 1.  Find the **kafka** package and click the **Install Package** button and accept the default installation. Kafka will spin up 3 brokers.
 1.  Find the **marathon-lb** package and click the **Install Package** button and accept the default installation.
-1.  Install Zeppelin.
-    1.  Find the **zeppelin** package and click the **Install Package** button and choose the **Advanced Installation** option.
-    1.  Click the **spark** tab and set `cores_max` to `8`.
-    1.  Click **Review and Install** and complete your installation.
 1.  Monitor the **Services** tab to watch as your microservices are deployed on DC/OS. You will see the Health status go from Idle to Unhealthy, and finally to Healthy as the nodes come online. This may take several minutes.
+
+Now we want to install **Zeppelin** with a specific version from the CLI to work around a temporary package issue in the latest version, use the [zeppelin-config.json](zeppelin-config.json) in this repository in the following command:
+
+    ```bash
+    $dcos package install zeppelin --package-version=0.5.6 --options=zeppelin-config.json
+    ```
 
     **Tip:** It can take up to 10 minutes for Cassandra to initialize with DC/OS because of race conditions.
 

--- a/tweeter/1.9/README.md
+++ b/tweeter/1.9/README.md
@@ -38,13 +38,11 @@ __Tip:__ You can also install DC/OS packages from the DC/OS CLI with the [`dcos 
 
 Now we want to install **Zeppelin** with a specific version from the CLI to work around a temporary package issue in the latest version, use the [zeppelin-config.json](zeppelin-config.json) in this repository.
 
-    ```bash
     $ dcos package install zeppelin --package-version=0.5.6 --options=zeppelin-config.json
-    ```
 
-    **Tip:** It can take up to 10 minutes for Cassandra to initialize with DC/OS because of race conditions.
+**Tip:** It can take up to 10 minutes for Cassandra to initialize with DC/OS because of race conditions.
 
-    ![Deployed services](./img/tweeter-deployed-services.png)
+![Deployed services](./img/tweeter-deployed-services.png)
 
 # Deploy the containerized app
 

--- a/tweeter/1.9/zeppelin-config.json
+++ b/tweeter/1.9/zeppelin-config.json
@@ -1,0 +1,11 @@
+{
+  "service": {
+    "name": "zeppelin",
+    "zeppelin_java_opts": "-Dspark.mesos.coarse=true -Dspark.mesos.executor.home=/opt/spark/dist"
+  },
+  "spark": {
+    "uri": "https://downloads.mesosphere.com/spark/assets/spark-2.1.1-bin-2.7.tgz",
+    "executor_docker_image": "mesosphere/spark:1.1.0-2.1.1-hadoop-2.7",
+    "cores_max": "8"
+  }
+}


### PR DESCRIPTION
The latest version of Zeppelin in the Universe doesn't work with
this demo. Specify an earlier version until the problem is fixed
with the package and add a json file so the "set cores_max to 8"
bit of the spark default configuration of this package is intact.