### PR TITLE
Change marathon apps to call local json

### DIFF
--- a/flink/1.9/README.md
+++ b/flink/1.9/README.md
@@ -96,7 +96,9 @@ and
 
 After the Kafka queues are created, we can now deploy the [data generator](https://github.com/dcos/demos/blob/master/flink/1.9/generator/generator.go) with this [marathon app definition](https://github.com/dcos/demos/blob/master/flink/1.9/generator/generator.json). As the GoLang generator contains all its dependencies, the app defintion doesn't require a container image and is running without Docker.
 
-`dcos marathon app add https://raw.githubusercontent.com/dcos/demos/master/flink/1.9/generator/generator.json`
+`cd flink/1.9`
+
+`dcos marathon app add generator/generator.json`
 
 
 ### Flink
@@ -135,7 +137,7 @@ Once we hit Submit, we should see the job begin to run in the Flink web UI.
 Now once the Flink job is running, we only need a way to visualize the results. We do that with another [simple GoLang program](https://github.com/dcos/demos/blob/master/flink/1.9/actor/actor_viewer.go).
 
 `
-dcos marathon app add https://raw.githubusercontent.com/dcos/demos/master/flink/1.9/actor/fraudDisplay.json
+dcos marathon app add actor/fraudDisplay.json
 `
 
 We can easily check the output by checking the task output from the UI.


### PR DESCRIPTION
As referenced in https://dcosjira.atlassian.net/browse/DCOS-618, 

running marathon app via `raw.githubusercontent.com` gives the following error 
`Can't read from resource: https://raw.githubusercontent.com/dcos/demos/master/flink/1.9/actor/fraudDisplay.json.
Please check that it exists.`