### PR TITLE
Fintrans reorg numbering and inline URL fix

### DIFF
--- a/fintrans/1.9/README.md
+++ b/fintrans/1.9/README.md
@@ -59,7 +59,7 @@ After either single command install or manual install method your DC/OS UI shoul
 If you want to install the demo with a single command, use:
 
 ```bash
-$ cd $DEMO_HOME/1.9/fintrans
+$ cd $DEMO_HOME/fintrans/1.9
 $ ./install-all.sh
 ```
 
@@ -74,7 +74,7 @@ If you want to install the demo manually here are the required services that you
 Install InfluxDB with the following [options](influx-ingest/influx-config.json):
 
 ```bash
-$ cd $DEMO_HOME/1.9/fintrans/influx-ingest/
+$ cd $DEMO_HOME/fintrans/1.9/influx-ingest/
 $ dcos package install --options=influx-config.json influxdb
 ```
 
@@ -115,7 +115,7 @@ Note that if you came here from the single command install then you're done: you
 Install the Apache Kafka package with the following [options](kafka-config.json):
 
 ```bash
-$ cd $DEMO_HOME/1.9/fintrans/
+$ cd $DEMO_HOME/fintrans/1.9/
 $ dcos package install kafka --options=kafka-config.json
 ```
 
@@ -145,7 +145,7 @@ Note the FQDN for the broker, in our case `broker-0.kafka.mesos:9398`, you will 
 Last but not least it's time to launch the financial transaction generator and the consumers:
 
 ```bash
-$ cd $DEMO_HOME/1.9/fintrans/
+$ cd $DEMO_HOME/fintrans/1.9/
 $ ./install-services.sh
 deploying the fintrans generator ...
 Created deployment 56d3e77d-08e6-4a43-87cd-bcc6a107e8c3
@@ -196,7 +196,7 @@ The core piece of this demo is consuming the financial transactions in some mean
 One consumer of the transactions we stored in Kafka is a combination of InfluxDB and Grafana, called the [influx-ingest](influx-ingest/) consumer.
 This consumer uses Grafana as the visual frontend, showing a breakdown of average and total transaction volume per city for the past hour. 
 
-Now, to see the recent financial transaction streaming in, locate the Grafana dashboard at `$PUBLIC_AGENT_IP:13000` (note: you might need to [find out the IP of the public agent](https://dcos.io/docs/1.9/administration/locate-public-agent/ first) and log in with: `admin`/`admin`. Once logged in, create a new Grafana dashboard by loading the prepared [Grafana dashboard json file](influx-ingest/grafana-dashboard.json) and you should see something like this:
+Now, to see the recent financial transaction streaming in, locate the Grafana dashboard at `$PUBLIC_AGENT_IP:13000` (note: you might need to [find out the IP of the public agent](https://dcos.io/docs/1.9/administration/locate-public-agent/ ) first and log in with: `admin`/`admin`. Once logged in, create a new Grafana dashboard by loading the prepared [Grafana dashboard json file](influx-ingest/grafana-dashboard.json) and you should see something like this:
 
 ![Transactions in Grafana](img/grafana-dashboard.png)
 
@@ -276,7 +276,7 @@ Note that it is necessary to [add the announced DNS servers]( https://support.ap
 For a local dev/test setup, and with [DC/OS VPN tunnel](#tunneling) enabled, we can run the fintrans generator as follows:
 
 ```bash
-$ cd $DEMO_HOME/1.9/fintrans/generator/
+$ cd $DEMO_HOME/fintrans/1.9/generator/
 $ go build
 $ ./generator --broker broker-0.kafka.mesos:9398
 INFO[0001] &sarama.ProducerMessage{Topic:"London", Key:sarama.Encoder(nil), Value:"678 816 2957", Metadata:interface {}(nil), Offset:10, Partition:0, Timestamp:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}, retries:0, flags:0}
@@ -288,7 +288,7 @@ INFO[0005] &sarama.ProducerMessage{Topic:"London", Key:sarama.Encoder(nil), Valu
 Again, assuming [DC/OS VPN tunnel](#tunneling) is enabled, you can run the recent transactions dashboard (feeding InfluxDB/Grafana) from your local development machine as follows. First, you need to find out the InfluxDB API URL and provide it via the environment variable `INFLUX_API` (in our case, looking up where the InfluxDB instance runs, using the higher of the two ports, the URL is `http://10.0.3.178:11973`):
 
 ```bash
-$ cd $DEMO_HOME/1.9/fintrans/influx-ingest/
+$ cd $DEMO_HOME/fintrans/1.9/influx-ingest/
 $ go build
 $ INFLUX_API=http://10.0.3.178:11973 ./influx-ingest --broker broker-0.kafka.mesos:9398
 INFO[0003] Got main.Transaction{City:"Tokyo", Source:"836", Target:"378", Amount:1211}  func=consume
@@ -302,7 +302,7 @@ INFO[0003] Ingested &client.batchpoints{points:[]*client.Point{(*client.Point)(0
 You can launch the money laundering detector as follows from your local development machine (note: [DC/OS VPN tunnel](#tunneling) must be enabled):
 
 ```bash
-$ cd $DEMO_HOME/1.9/fintrans/laundering-detector/
+$ cd $DEMO_HOME/fintrans/1.9/laundering-detector/
 $ go build
 $ ALERT_THRESHOLD=6000 PROD_OUTPUT=false ./laundering-detector --broker broker-0.kafka.mesos:9398
 INFO[0002] Queued main.Transaction{City:"SF", Source:"970", Target:"477", Amount:1102}  func=consume


### PR DESCRIPTION
Fix the cd commands for getting to the scripts post reorg and
fix up one of the inline URLs which isn't linking properly when
rendered.