### PR TITLE
Remove Geospatial-IOT from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Overview of demos in 1.9:
 
 * [Application Logs](applogs/1.9#fast-data-application-logs)
 * [Financial Transaction Processing](fintrans/1.9#fast-data-financial-transaction-processing)
+* [Apache Flink Stream Processing](flink/1.9#fast-data-financial-transaction-processing-with-apache-flink)
 * [Iot Fast Data Analytics](fastdata-iot/1.9#iot-fast-data-analytics)
-* [Geospatial IoT](geospatial-iot/1.9)
 * [Sensor Analytics](sensoranalytics/1.9#fast-data-sensor-analytics)
 * [Tweeter](tweeter/1.9#tweeter)
 


### PR DESCRIPTION
Remove link to geospatial-iot/1.9 since it's being rewritten and
currently mistakenly has the Tweeter demo contents, being tracked
in https://jira.mesosphere.com/browse/DCOS_COMMUNITY-9