### PR TITLE
fix invalid nlp preprocessor uri

### DIFF
--- a/nlp/1.10/preprocessor/preprocessor.json
+++ b/nlp/1.10/preprocessor/preprocessor.json
@@ -2,7 +2,7 @@
   "id": "preprocessor",
   "instances": 1,
   "fetch": [{
-    "uri": "https://raw.githubusercontent.com/dcos/demos/nlp/1.10/master/preprocessor/preprocessor_linux",
+    "uri": "https://raw.githubusercontent.com/dcos/demos/master/nlp/1.10/preprocessor/preprocessor_linux",
     "executable": true
   }],
   "cpus": 0.1,


### PR DESCRIPTION
uri of preprocessor_linux for preprocessor marathon deployment is invalid, so that mesos-agent cannot fetch preprocessor_linux, and preprocessor will not be running.

Fix this by change the uri to the right one.