### PR TITLE
Make Spark work on 1.12.1

### DIFF
--- a/fastdata-iot/1.11/README.md
+++ b/fastdata-iot/1.11/README.md
@@ -52,7 +52,7 @@ or Kafka via the Akka backendsystem.
 Install the DC/OS Apache Spark package (Version 1.0.2-2.0.0 or higher):
 
 ```bash
-dcos package install spark --options=configuration/spark.json
+dcos package install spark --options=configuration/spark.json --package-version=2.5.0-2.2.1
 ```
 
 ### Cassandra
@@ -126,7 +126,7 @@ Using the UI, copy and paste the JSON into the JSON editor:
     "type": "MESOS",
     "volumes": [],
     "docker": {
-      "image": "mesosphere/akka-ingest:0.2.1-SNAPSHOT",
+      "image": "mesosphere/akka-ingest:0.2.2",
       "privileged": false,
       "parameters": [],
       "forcePullImage": true

--- a/fastdata-iot/1.11/README.md
+++ b/fastdata-iot/1.11/README.md
@@ -52,7 +52,7 @@ or Kafka via the Akka backendsystem.
 Install the DC/OS Apache Spark package (Version 1.0.2-2.0.0 or higher):
 
 ```bash
-dcos package install spark
+dcos package install spark --options=configuration/spark.json
 ```
 
 ### Cassandra

--- a/fastdata-iot/1.11/configuration/spark.json
+++ b/fastdata-iot/1.11/configuration/spark.json
@@ -1,0 +1,7 @@
+{
+  "service": {
+    "name": "fastdata-spark",
+    "user": "root",
+    "use_bootstrap_for_IP_detect": true
+  }
+}

--- a/fastdata-iot/1.11/configuration/spark.json
+++ b/fastdata-iot/1.11/configuration/spark.json
@@ -1,7 +1,7 @@
 {
-  "service": {
-    "name": "fastdata-spark",
-    "user": "root",
-    "use_bootstrap_for_IP_detect": true
-  }
+    "service": {
+        "user": "root",
+        "name": "spark",
+        "use_bootstrap_for_IP_detect": true
+    }
 }


### PR DESCRIPTION
Added Spark configfile, setting user as root. Default user is nobody which prevents the spark service from starting. Also setting use_bootstrap_for_IP_detect which appears to be required top make spark work on AWS at least.